### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bedirhan-kurt/ChatFlow/security/code-scanning/1](https://github.com/bedirhan-kurt/ChatFlow/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the minimal permissions required. Based on the workflow's steps, the following permissions are likely needed:
- `contents: read` to allow the workflow to read the repository contents.
- `id-token: write` to allow the Firebase action to authenticate using OpenID Connect (OIDC) if required.

We will add these permissions to the root of the workflow to apply them to all jobs. If additional permissions are required for specific steps, they can be added later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
